### PR TITLE
django.conf.urls.defaults deprecated in Django 1.6

### DIFF
--- a/attachments/urls.py
+++ b/attachments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('',
     url(r'^add-for/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$', 'attachments.views.add_attachment', name="add_attachment"),


### PR DESCRIPTION
Due to django.conf.urls.defaults deprecated in Django 1.6 we should use django.conf.urls
