### PR TITLE
custom user model may not have a field called `username`

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -41,7 +41,7 @@ class Attachment(models.Model):
         )
 
     def __unicode__(self):
-        return '%s attached %s' % (self.creator.username, self.attachment_file.name)
+        return '%s attached %s' % (self.creator.get_username(), self.attachment_file.name)
 
     @property
     def filename(self):


### PR DESCRIPTION
use this method from Django's provided `AbstractBaseUser` class instead
