### PR TITLE
Explicitly include patterns from django.conf.urls

### DIFF
--- a/attachments/urls.py
+++ b/attachments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('',
     url(r'^add-for/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$', 'attachments.views.add_attachment', name="add_attachment"),


### PR DESCRIPTION
This should fix issue #24. Rather than importing * I import patterns and url explicitly in urls.py. It fixed the issue for me.