### PR TITLE
Fixes problems where models primary key is not named `id`

### DIFF
--- a/attachments/forms.py
+++ b/attachments/forms.py
@@ -15,5 +15,5 @@ class AttachmentForm(forms.ModelForm):
     def save(self, request, obj, *args, **kwargs):
         self.instance.creator = request.user
         self.instance.content_type = ContentType.objects.get_for_model(obj)
-        self.instance.object_id = obj.id
+        self.instance.object_id = obj.pk
         super(AttachmentForm, self).save(*args, **kwargs)

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -22,7 +22,7 @@ class AttachmentManager(models.Manager):
     def attachments_for_object(self, obj):
         object_type = ContentType.objects.get_for_model(obj)
         return self.filter(content_type__pk=object_type.id,
-                           object_id=obj.id)
+                           object_id=obj.pk)
 
 
 class Attachment(models.Model):


### PR DESCRIPTION
Replaces 2 instances where the `pk` is referred to as `obj.id`.  This commit allows for models to have a primary key not named `id` using the shortcut `obj.pk`.