### PR TITLE
Add new template tag attachments_count

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,14 +106,19 @@ for your model objects in your frontend.
 
    {% get_attachments_for entry as "attachments_list" %}
 
-2. ``attachment_form``: Renders a upload form to add attachments for the given
+2. ``attachments_count [object]``: Counts the attachments for the given
+   model instance and returns an int::
+
+   {% attachments_count entry %}
+
+3. ``attachment_form``: Renders a upload form to add attachments for the given
    model instance. Example::
 
     {% attachment_form [object] %}
 
    It returns an empty string if the current user is not logged in.
 
-3. ``attachment_delete_link``: Renders a link to the delete view for the given
+4. ``attachment_delete_link``: Renders a link to the delete view for the given
    *attachment*. Example::
 
     {% for att in attachments_list %}
@@ -132,6 +137,7 @@ Quick Example:
     {% load attachments_tags %}
     {% get_attachments_for entry as my_entry_attachments %}
 
+    <span>Object has {% attachments_count entry %} attachments</span>
     {% if my_entry_attachments %}
     <ul>
     {% for attachment in my_entry_attachments %}

--- a/attachments/templatetags/attachments_tags.py
+++ b/attachments/templatetags/attachments_tags.py
@@ -50,6 +50,15 @@ def attachment_delete_link(context, attachment):
         }
     return {'delete_url': None}
 
+@register.simple_tag
+def attachments_count(obj):
+    """
+    Counts attachments that are attached to a given object.
+
+        {% attachments_count obj %}
+    """
+    return Attachment.objects.attachments_for_object(obj).count()
+
 if django.VERSION < (1, 9):
     # simple_tag in Django 1.8 doesn't have the functionality we need, so use
     # assignment_tag instead. See:

--- a/attachments/tests/test_template.py
+++ b/attachments/tests/test_template.py
@@ -20,6 +20,14 @@ class ViewTestCase(BaseTestCase):
         attachment = Attachment.objects.attachments_for_object(self.obj)[0]
         self.assertTrue(attachment.attachment_file.url in str(response.content))
 
+    def test_attachment_count_is_listed(self):
+        self.client.login(**self.cred_jon)
+        self._upload_testfile()
+        self._upload_testfile()
+        response = self.client.get(self.item_url)
+        attachment_count = Attachment.objects.attachments_for_object(self.obj).count()
+        self.assertTrue("Object has %d attachments" % attachment_count in str(response.content))
+
     def test_upload_form_is_listed_with_add_permission(self):
         self.client.login(**self.cred_jon)
         response = self.client.get(self.item_url)

--- a/attachments/tests/testapp/templates/testmodel_detail.html
+++ b/attachments/tests/testapp/templates/testmodel_detail.html
@@ -1,6 +1,7 @@
 {% load attachments_tags %}
 
 <h1>{{ object.title }}</h1>
+<h2>Object has {% attachments_count object %} attachments</h2>
 
 {% get_attachments_for object as attachments_list %}
 {% for att in attachments_list %}


### PR DESCRIPTION
I have migrated a large application to django-attachments and there are only a few things that I'm missing. The first is an easy way to count how many attachments are there for a given object. We use this very heavily in templates and this tag will solve the issue.