### PR TITLE
Respect FILE_UPLOAD_MAX_SIZE setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - pip install codecov
 
 install:
-  - pip install django==$DJANGO
+  - pip install six django==$DJANGO
   - pip install -e .
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ Installation:
 6. Set ``DELETE_ATTACHMENTS_FROM_DISK`` to ``True`` if you want to remove
    files from disk when Attachment objects are removed!
 
+7. Configure ``FILE_UPLOAD_MAX_SIZE`` (optional). This is the maximum size in
+   bytes before raising form validation errors. If not set there is no restriction
+   on file size.
+
 Mind that you serve files!
 ==========================
 

--- a/attachments/forms.py
+++ b/attachments/forms.py
@@ -1,11 +1,22 @@
 from attachments.models import Attachment
 from django import forms
-from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+from django.template.defaultfilters import filesizeformat
+from django.contrib.contenttypes.models import ContentType
 
+
+def validate_max_size(data):
+    if hasattr(settings, 'FILE_UPLOAD_MAX_SIZE') and \
+       data.size > settings.FILE_UPLOAD_MAX_SIZE:
+        raise forms.ValidationError(
+            _('File exceeds maximum size of %s') % \
+            filesizeformat(settings.FILE_UPLOAD_MAX_SIZE)
+        )
 
 class AttachmentForm(forms.ModelForm):
-    attachment_file = forms.FileField(label=_('Upload attachment'))
+    attachment_file = forms.FileField(label=_('Upload attachment'),
+                                      validators=[validate_max_size])
 
     class Meta:
         model = Attachment

--- a/attachments/tests/test_views.py
+++ b/attachments/tests/test_views.py
@@ -43,6 +43,24 @@ class ViewTestCase(BaseTestCase):
         self.assertEqual(Attachment.objects.count(), 0)
         self.assertEqual(Attachment.objects.attachments_for_object(self.obj).count(), 0)
 
+    def test_upload_size_less_than_limit(self):
+        # NOTE: in all of the other tests there's no limit specified
+        # so they will cover the branch where the setting is missing
+        with self.settings(FILE_UPLOAD_MAX_SIZE=1024):
+            self.client.login(**self.cred_jon)
+            self._upload_testfile()
+            self.assertEqual(Attachment.objects.count(), 1)
+            self.assertEqual(Attachment.objects.attachments_for_object(self.obj).count(), 1)
+
+    def test_upload_size_more_than_limit(self):
+        # we set a limit of 1 byte b/c the file used for testing
+        # is very small
+        with self.settings(FILE_UPLOAD_MAX_SIZE=1):
+            self.client.login(**self.cred_jon)
+            self._upload_testfile()
+            self.assertEqual(Attachment.objects.count(), 0)
+            self.assertEqual(Attachment.objects.attachments_for_object(self.obj).count(), 0)
+
     def test_upload_without_permission(self):
         """
         Remove the 'add permission' and try to upload a file.


### PR DESCRIPTION
This PR implements max file size validation. 

@bartTC in case of error I'm seeing the following message
"File exceeds maximum size of 1.2В MB"

Notice the "B" char after "1.2". I'm not sure where this comes from, I think it is from `form.as_p`. `filesizeformat` in this case happily returns "1.2 MB".

Note2: I don't have any tests and also not sure if it will work on older Django but works for me locally.