### PR TITLE
fixes __str__ method on attachment model

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -46,7 +46,7 @@ class Attachment(models.Model):
         )
 
     def __str__(self):
-        return _('{username} attached {filename}') % {
+        return _('%(username)s attached %(filename)s') % {
             'username': self.creator.get_username(),
             'filename': self.attachment_file.name
         }

--- a/attachments/tests/test_model.py
+++ b/attachments/tests/test_model.py
@@ -1,0 +1,13 @@
+from attachments.models import Attachment
+
+from .base import BaseTestCase
+
+
+class ModelTestCase(BaseTestCase):
+
+    def test_str_return_value(self):
+        self.client.login(**self.cred_jon)
+        self._upload_testfile()
+        attachment = Attachment.objects.attachments_for_object(self.obj)[0]
+        correct_str = '{0.creator.username} attached {0.attachment_file.name}'.format(attachment)
+        self.assertEqual(str(attachment), correct_str)


### PR DESCRIPTION
Adds a test to show that the model __str__ is not working

Modifies the __str__ method on `models.py` to interpolate strings correctly. 