### PR TITLE
Allow overriding of next URL in attachment_form tag

### DIFF
--- a/attachments/templatetags/attachments_tags.py
+++ b/attachments/templatetags/attachments_tags.py
@@ -9,7 +9,7 @@ register = Library()
 
 
 @register.inclusion_tag('attachments/add_form.html', takes_context=True)
-def attachment_form(context, obj):
+def attachment_form(context, obj, **kwargs):
     """
     Renders a "upload attachment" form.
 
@@ -20,7 +20,7 @@ def attachment_form(context, obj):
         return {
             'form': AttachmentForm(),
             'form_url': add_url_for_obj(obj),
-            'next': context.request.build_absolute_uri(),
+            'next': kwargs.get('next', context.request.build_absolute_uri()),
         }
     else:
         return {'form': None}


### PR DESCRIPTION
This allows the user to override the next URL in their own templates. 

For example, in my case this form appears inside a fairly complex page with lots of the widgets on the page loaded via AJAX (HTML via AJAX, it's legacy) and the absolute URL that is constructed matches the URL from where the widget is loaded but not the page on which it is shown.

Note: I'd appreciate if you can merge this and release a new update fairly quickly!