### PR TITLE
Don't use deprecated django.conf.urls.url()

### DIFF
--- a/attachments/tests/testapp/urls.py
+++ b/attachments/tests/testapp/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import include, url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
+
+from django.conf.urls import include
 from django.contrib import admin
 from django.views.generic import DetailView
 

--- a/attachments/urls.py
+++ b/attachments/urls.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .views import add_attachment, delete_attachment
 


### PR DESCRIPTION
Use django.urls.re_path() instead. Silences
RemovedInDjango40Warning warnings when running with Django 3.1