### PR TITLE
Add Attachment.attach_to() method for moving attachments around

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -62,3 +62,25 @@ class Attachment(models.Model):
     @property
     def filename(self):
         return os.path.split(self.attachment_file.name)[1]
+
+    def attach_to(self, new_object, update_path=False):
+        """
+            Attach to a new object and possibly move the actual file on disk!
+
+            .. important::
+
+                As long as path names are valid you can continue serving
+                the files from their original path and not change it!
+        """
+        self.object_id = new_object.pk
+        self.content_type = ContentType.objects.get_for_model(new_object)
+        self.save()
+
+        if update_path:
+            old_path = self.attachment_file.path
+            self.attachment_file.name = attachment_upload(self, self.filename)
+            self.attachment_file.save()
+
+            os.makedirs(
+                os.path.dirname(self.attachment_file.path), exist_ok=True)
+            os.rename(old_path, self.attachment_file.path)


### PR DESCRIPTION
@bartTC I think I've got an answer to my question in #73. My intention is to first attach files to `request.user` and then a `post_save` signal handler will inspect the document text & files for the user and just move them around to the new object. This will solve my problems with how these files appear in the UI. FTR I don't intend to change the file paths on disk but that's a good feature to have too. This method is what I require to solve the issues in my own project.