### PR TITLE
Make remove_file_from_disk() use Django's default_storage

### DIFF
--- a/attachments/tests/test_views.py
+++ b/attachments/tests/test_views.py
@@ -4,6 +4,7 @@ import mock
 
 from http import HTTPStatus
 from django.urls import reverse
+from django.core.files.storage import default_storage
 
 from ..models import Attachment
 from .base import BaseTestCase
@@ -217,7 +218,7 @@ class ViewTestCase(BaseTestCase):
         self._upload_testfile()
         att = Attachment.objects.first()
 
-        with mock.patch("attachments.views.os.remove") as _mock:
+        with mock.patch.object(default_storage, "delete") as _mock:
             _mock.side_effect = OSError("Test file does not exist")
             with self.settings(DELETE_ATTACHMENTS_FROM_DISK=True):
                 del_url = reverse(

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
-import os
-
 from http import HTTPStatus
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.files.storage import default_storage
 from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -31,10 +30,10 @@ def add_url_for_obj(obj):
 def remove_file_from_disk(f):
     if getattr(
         settings, "DELETE_ATTACHMENTS_FROM_DISK", False
-    ) and os.path.exists(f.path):
+    ) and default_storage.exists(f.name):
         try:
-            os.remove(f.path)
-        except OSError:
+            default_storage.delete(f.name)
+        except Exception:
             pass
 
 


### PR DESCRIPTION
should make this function work not only with FileSystemStorage but also with cloud providers like AWS S3 for example!